### PR TITLE
Fix broken external links

### DIFF
--- a/05-memory-and-context/README.md
+++ b/05-memory-and-context/README.md
@@ -250,7 +250,7 @@ State is useful because it gives the agent quick access to important facts witho
 Google Cloud provides session management through the Agent Development Kit (ADK) and Vertex AI:
 
 - **ADK Sessions:** The [ADK session system](https://google.github.io/adk-docs/sessions/) provides built-in session management with event tracking and state.
-- **Vertex AI Sessions:** [Vertex AI Agent Engine sessions](https://cloud.google.com/vertex-ai/generative-ai/docs/agent-engine/manage/sessions) offer managed session storage with automatic scaling.
+- **Vertex AI Sessions:** [Vertex AI Agent Engine sessions](https://cloud.google.com/agent-builder/agent-engine/sessions/overview) offer managed session storage with automatic scaling.
 
 These handle the infrastructure of storing and retrieving sessions, so you can focus on the agent logic.
 
@@ -589,7 +589,7 @@ The context engineering layer assembles the right context *before* the LLM sees 
 ## Further reading
 
 - [ADK Sessions documentation](https://google.github.io/adk-docs/sessions/)
-- [Vertex AI Agent Engine - Manage Sessions](https://cloud.google.com/vertex-ai/generative-ai/docs/agent-engine/manage/sessions)
+- [Vertex AI Agent Engine - Manage Sessions](https://cloud.google.com/agent-builder/agent-engine/sessions/overview)
 - [Vertex AI Vector Search](https://cloud.google.com/vertex-ai/docs/vector-search/overview)
 - [Google Cloud AI codelabs](https://codelabs.developers.google.com/?cat=AI)
 

--- a/14-agent-protocols-mcp-and-a2a/README.md
+++ b/14-agent-protocols-mcp-and-a2a/README.md
@@ -300,7 +300,7 @@ This is one of the most important distinctions to understand:
 - You would use **MCP** to connect to a flight search API (a tool that takes departure city, arrival city, and date, and returns flights)
 - You would use **A2A** to delegate to a hotel booking agent that can understand preferences like "somewhere quiet near the conference venue" and figure out the best options on its own
 
-> **Learn more:** [A2A in ADK](https://google.github.io/adk-docs/a2a/) and [A2A Protocol Spec](https://developers.google.com/a2a)
+> **Learn more:** [A2A in ADK](https://google.github.io/adk-docs/a2a/) and [A2A Protocol Spec](https://a2a-protocol.org/latest/)
 
 ---
 
@@ -487,7 +487,7 @@ Both protocols are actively evolving. Expect to see:
 
 - **MCP Tools in ADK:** [https://google.github.io/adk-docs/tools/mcp-tools/](https://google.github.io/adk-docs/tools/mcp-tools/)
 - **A2A in ADK:** [https://google.github.io/adk-docs/a2a/](https://google.github.io/adk-docs/a2a/)
-- **A2A Protocol Specification:** [https://developers.google.com/a2a](https://developers.google.com/a2a)
+- **A2A Protocol Specification:** [https://a2a-protocol.org/latest/](https://a2a-protocol.org/latest/)
 - **MCP Specification:** [https://modelcontextprotocol.io](https://modelcontextprotocol.io)
 
 ---

--- a/18-orchestrators/README.md
+++ b/18-orchestrators/README.md
@@ -136,7 +136,7 @@ pipeline = SequentialAgent(
 )
 ```
 
-See the [ADK SequentialAgent documentation](https://google.github.io/adk-docs/agents/workflow-agents/sequential-agent/) for implementation details.
+See the [ADK SequentialAgent documentation](https://adk.dev/agents/workflow-agents/sequential-agents/) for implementation details.
 
 ### Parallel (fan-out / gather)
 
@@ -169,7 +169,7 @@ review = ParallelAgent(
 )
 ```
 
-See the [ADK ParallelAgent documentation](https://google.github.io/adk-docs/agents/workflow-agents/parallel-agent/) for implementation details.
+See the [ADK ParallelAgent documentation](https://adk.dev/agents/workflow-agents/parallel-agents/) for implementation details.
 
 ### Loop (iterative refinement)
 
@@ -209,7 +209,7 @@ refiner = LoopAgent(
 )
 ```
 
-See the [ADK LoopAgent documentation](https://google.github.io/adk-docs/agents/workflow-agents/loop-agent/) for implementation details.
+See the [ADK LoopAgent documentation](https://adk.dev/agents/workflow-agents/loop-agents/) for implementation details.
 
 ### Routing (handoff / dispatch)
 

--- a/19-where-to-go-from-here/README.md
+++ b/19-where-to-go-from-here/README.md
@@ -195,7 +195,7 @@ Each framework makes different trade-offs. ADK emphasizes Google Cloud integrati
 ### Protocol implementations
 
 - **MCP Specification:** [modelcontextprotocol.io](https://modelcontextprotocol.io) - The protocol spec and reference implementations
-- **A2A Protocol:** [developers.google.com/a2a](https://developers.google.com/a2a) - Specification and documentation
+- **A2A Protocol:** [a2a-protocol.org](https://a2a-protocol.org/latest/) - Specification and documentation
 
 ---
 
@@ -346,7 +346,7 @@ Keep these links handy. They are the primary references you will come back to:
 
 **Protocols:**
 - MCP Specification: [https://modelcontextprotocol.io](https://modelcontextprotocol.io)
-- A2A Protocol: [https://developers.google.com/a2a](https://developers.google.com/a2a)
+- A2A Protocol: [https://a2a-protocol.org/latest/](https://a2a-protocol.org/latest/)
 - MCP Tools in ADK: [https://google.github.io/adk-docs/tools/mcp-tools/](https://google.github.io/adk-docs/tools/mcp-tools/)
 
 **Open Source:**


### PR DESCRIPTION
## Summary

- Update Vertex AI session URLs to new Agent Builder path (2 occurrences in `05-memory-and-context`)
- Update A2A protocol spec URLs from `developers.google.com/a2a` to `a2a-protocol.org/latest/` (4 occurrences across `14-agent-protocols-mcp-and-a2a` and `19-where-to-go-from-here`)
- Update ADK workflow agent URLs from `google.github.io/adk-docs` to `adk.dev` with pluralised slugs (3 occurrences in `18-orchestrators`)

All broken links were detected with [lychee](https://lychee.cli.rs).

## AI disclosure

This PR was prepared with the help of Claude Code (Claude Opus 4.6). The broken links were identified by lychee; replacement URLs were sourced from the BROKEN_LINKS.md report and verified by a human before submission.